### PR TITLE
 #23 - Add toggleSpeaker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ type TwilioPhoneType = {
   endCall(callSid: string): void;
   toggleMuteCall(callSid: string, mute: boolean): void;
   toggleHoldCall(callSid: string, hold: boolean): void;
+  toggleSpeaker(speakerOn: boolean): void;
   sendDigits(callSid: string, digits: string): void;
   startCall(accessToken: string, params: ConnectParams): void;
   unregister(accessToken: string, deviceToken: string): void;

--- a/android/src/main/java/com/reactnativetwiliophone/TwilioPhoneModule.kt
+++ b/android/src/main/java/com/reactnativetwiliophone/TwilioPhoneModule.kt
@@ -1,6 +1,8 @@
 package com.reactnativetwiliophone
 
+import android.content.Context
 import android.content.pm.PackageManager
+import android.media.AudioManager
 import android.os.Bundle
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -18,6 +20,8 @@ class TwilioPhoneModule(reactContext: ReactApplicationContext) : ReactContextBas
   private var activeCalls = mutableMapOf<String, Call>()
 
   private var callListener = callListener()
+
+  private var audioManager: AudioManager = reactContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager;
 
   override fun getName(): String {
     return "TwilioPhone"
@@ -163,6 +167,12 @@ class TwilioPhoneModule(reactContext: ReactApplicationContext) : ReactContextBas
     val activeCall = activeCalls[callSid] ?: return
 
     activeCall.hold(hold)
+  }
+
+  @ReactMethod
+  fun toggleSpeaker(speakerOn: Boolean) {
+    Log.i(tag, "Toggling speaker")
+    audioManager.setSpeakerphoneOn(speakerOn);
   }
 
   @ReactMethod

--- a/ios/TwilioPhone.m
+++ b/ios/TwilioPhone.m
@@ -19,6 +19,8 @@ RCT_EXTERN_METHOD(toggleMuteCall:(NSString *)callSid withMute:(BOOL *)mute)
 
 RCT_EXTERN_METHOD(toggleHoldCall:(NSString *)callSid withHold:(BOOL *)hold)
 
+RCT_EXTERN_METHOD(toggleSpeaker:(BOOL *)speakerOn)
+
 RCT_EXTERN_METHOD(sendDigits:(NSString *)callSid withDigits:(NSString *)digits)
 
 RCT_EXTERN_METHOD(startCall:(NSString *)accessToken withParams:(NSDictionary *)params)

--- a/ios/TwilioPhone.swift
+++ b/ios/TwilioPhone.swift
@@ -4,11 +4,11 @@ import TwilioVoice
 class TwilioPhone: RCTEventEmitter {
     var hasListeners = false
     var audioDevice = DefaultAudioDevice()
-    
+
     var activeCallInvites: [String: CallInvite]! = [:]
     var activeCalls: [String: Call]! = [:]
     var activeCall: Call?
-    
+
     override func supportedEvents() -> [String]! {
         return [
             "CallInvite",
@@ -26,95 +26,95 @@ class TwilioPhone: RCTEventEmitter {
             "UnregistrationFailure"
         ]
     }
-    
+
     override func startObserving() {
         hasListeners = true
     }
-    
+
     override func stopObserving() {
         hasListeners = false
     }
-    
+
     @objc
     override static func requiresMainQueueSetup() -> Bool {
         return true
     }
-    
+
     @objc(register:withDeviceToken:)
     func register(accessToken: String, deviceToken: String) {
         NSLog("[TwilioPhone] Registering")
-        
+
         let tokenData = hexToData(str: deviceToken)
-        
+
         TwilioVoiceSDK.register(accessToken: accessToken, deviceToken: tokenData) { error in
             if let error = error {
                 NSLog("[TwilioPhone] An error occurred while registering: \(error.localizedDescription)")
-                
+
                 if self.hasListeners {
                     self.sendEvent(withName: "RegistrationFailure", body: ["errorMessage": error.localizedDescription])
                 }
             } else {
                 NSLog("[TwilioPhone] Successfully registered for VoIP push notifications")
-                
+
                 if self.hasListeners {
                     self.sendEvent(withName: "RegistrationSuccess", body: nil)
                 }
             }
         }
     }
-    
+
     @objc(handleMessage:)
     func handleMessage(payload: [String: String]) {
         NSLog("[TwilioPhone] Handling message")
-        
+
         TwilioVoiceSDK.handleNotification(payload, delegate: self, delegateQueue: nil)
     }
-    
+
     @objc(acceptCallInvite:)
     func acceptCallInvite(callSid: String) {
         NSLog("[TwilioPhone] Accepting call invite")
-        
+
         guard let callInvite = activeCallInvites[callSid] else {
             NSLog("[TwilioPhone] No call invite to be accepted")
             return
         }
-        
+
         let call = callInvite.accept(with: self)
-        
+
         activeCalls[callSid] = call
         activeCallInvites.removeValue(forKey: callSid)
     }
-    
+
     @objc(rejectCallInvite:)
     func rejectCallInvite(callSid: String) {
         NSLog("[TwilioPhone] Rejecting call invite")
-        
+
         guard let callInvite = activeCallInvites[callSid] else {
             NSLog("[TwilioPhone] No call invite to be rejected")
             return
         }
-        
+
         callInvite.reject()
-        
+
         activeCallInvites.removeValue(forKey: callSid)
     }
-    
+
     @objc(disconnectCall:)
     func disconnectCall(callSid: String) {
         NSLog("[TwilioPhone] Disconnecting call")
-        
+
         guard let call = activeCalls[callSid] else {
             NSLog("[TwilioPhone] No call to be disconnected")
             return
         }
-        
+
         call.disconnect()
     }
-    
+
     @objc(endCall:)
     func endCall(callSid: String) {
         NSLog("[TwilioPhone] Ending call")
-        
+
         if let callInvite = activeCallInvites[callSid] {
             callInvite.reject()
             activeCallInvites.removeValue(forKey: callSid)
@@ -124,98 +124,116 @@ class TwilioPhone: RCTEventEmitter {
             NSLog("[TwilioPhone] Unknown sid to perform end-call action with")
         }
     }
-    
+
     @objc(toggleMuteCall:withMute:)
     func toggleMuteCall(callSid: String, mute: Bool) {
         NSLog("[TwilioPhone] Toggling mute call")
-        
+
         guard let activeCall = activeCalls[callSid] else {
             return
         }
-        
+
         activeCall.isMuted = mute
     }
-    
+
     @objc(toggleHoldCall:withHold:)
     func toggleHoldCall(callSid: String, hold: Bool) {
         NSLog("[TwilioPhone] Toggling hold call")
-        
+
         guard let activeCall = activeCalls[callSid] else {
             return
         }
-        
+
         activeCall.isOnHold = hold
     }
-    
+
+    @objc(toggleSpeaker:)
+    func toggleAudioRoute(speakerOn: Bool) {
+        audioDevice.block = {
+            DefaultAudioDevice.DefaultAVAudioSessionConfigurationBlock()
+            do {
+                if speakerOn {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
+                } else {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
+                }
+            } catch {
+                NSLog("[TwilioPhone] Failed to toggle speaker: \(error.localizedDescription)")
+            }
+        }
+
+        audioDevice.block()
+    }
+
     @objc(sendDigits:withDigits:)
     func sendDigits(callSid: String, digits: String) {
         NSLog("[TwilioPhone] Sending digits")
-        
+
         guard let activeCall = activeCalls[callSid] else {
             return
         }
-        
+
         activeCall.sendDigits(digits)
     }
-    
+
     @objc(startCall:withParams:)
     func startCall(accessToken: String, params: [String: String]) {
         NSLog("[TwilioPhone] Starting call")
-        
+
         let connectOptions = ConnectOptions(accessToken: accessToken) { builder in
             builder.params = params
         }
-        
+
         let call = TwilioVoiceSDK.connect(options: connectOptions, delegate: self)
-        
+
         activeCall = call
     }
-    
+
     @objc(unregister:withDeviceToken:)
     func unregister(accessToken: String, deviceToken: String) {
         NSLog("[TwilioPhone] Unregistering")
-        
+
         let tokenData = hexToData(str: deviceToken)
-        
+
         TwilioVoiceSDK.unregister(accessToken: accessToken, deviceToken: tokenData) { error in
             if let error = error {
                 NSLog("[TwilioPhone] An error occurred while unregistering: \(error.localizedDescription)")
-                
+
                 if self.hasListeners {
                     self.sendEvent(withName: "UnregistrationFailure", body: ["errorMessage": error.localizedDescription])
                 }
             } else {
                 NSLog("[TwilioPhone] Successfully unregistered from VoIP push notifications")
-                
+
                 if self.hasListeners {
                     self.sendEvent(withName: "UnregistrationSuccess", body: nil)
                 }
             }
         }
     }
-    
+
     @objc
     func activateAudio() {
         NSLog("[TwilioPhone] Activating audio")
-        
+
         audioDevice.isEnabled = true
     }
-    
+
     @objc
     func deactivateAudio() {
         NSLog("[TwilioPhone] Deactivating audio")
-        
+
         audioDevice.isEnabled = false
     }
-    
+
     @objc(checkPermissions:)
     func checkPermissions(callback: RCTResponseSenderBlock) {
         NSLog("[TwilioPhone] Checking permissions")
-        
+
         var permissions: [String: String] = [:]
-        
+
         let permissionStatus = AVAudioSession.sharedInstance().recordPermission
-        
+
         switch permissionStatus {
         case .granted:
             permissions["RECORD"] = "GRANTED"
@@ -223,29 +241,29 @@ class TwilioPhone: RCTEventEmitter {
             permissions["RECORD"] = "DENIED"
         case .undetermined:
             permissions["RECORD"] = "UNDETERMINED"
-            
+
             AVAudioSession.sharedInstance().requestRecordPermission { granted in
                 NSLog("[TwilioPhone] Record permission granted: \(granted)")
             }
         default:
             permissions["RECORD"] = "UNKNOWN"
         }
-        
+
         callback([permissions])
     }
-    
+
     func hexToData(str: String) -> Data {
         let len = str.count / 2
         var data = Data(capacity: len)
         let ptr = str.cString(using: String.Encoding.utf8)!
-        
+
         for i in 0..<len {
             var num: UInt8 = 0
             var multi: UInt8 = 16
             for j in 0..<2 {
                 let c = UInt8(ptr[i*2 + j])
                 var offset: UInt8 = 0
-                
+
                 switch c {
                 case 48...57: // '0'-'9'
                     offset = 48
@@ -256,7 +274,7 @@ class TwilioPhone: RCTEventEmitter {
                 default:
                     assert(false)
                 }
-                
+
                 num += (c - offset)*multi
                 multi = 1
             }
@@ -271,21 +289,21 @@ class TwilioPhone: RCTEventEmitter {
 extension TwilioPhone: CallDelegate {
     func callDidStartRinging(call: Call) {
         NSLog("[TwilioPhone] Call did start ringing")
-        
+
         activeCalls[call.sid] = call
-        
+
         if call == activeCall {
             activeCall = nil
         }
-        
+
         if hasListeners {
             sendEvent(withName: "CallRinging", body: ["callSid": call.sid])
         }
     }
-    
+
     func callDidFailToConnect(call: Call, error: Error) {
         NSLog("[TwilioPhone] Call failed to connect: \(error.localizedDescription)")
-        
+
         if hasListeners {
             sendEvent(withName: "CallConnectFailure", body: [
                 "callSid": call.sid,
@@ -293,18 +311,18 @@ extension TwilioPhone: CallDelegate {
             ])
         }
     }
-    
+
     func callDidConnect(call: Call) {
         NSLog("[TwilioPhone] Call did connect")
-        
+
         if hasListeners {
             sendEvent(withName: "CallConnected", body: ["callSid": call.sid])
         }
     }
-    
+
     func callIsReconnecting(call: Call, error: Error) {
         NSLog("[TwilioPhone] Call is reconnecting with error: \(error.localizedDescription)")
-        
+
         if hasListeners {
             sendEvent(withName: "CallReconnecting", body: [
                 "callSid": call.sid,
@@ -312,19 +330,19 @@ extension TwilioPhone: CallDelegate {
             ])
         }
     }
-    
+
     func callDidReconnect(call: Call) {
         NSLog("[TwilioPhone] Call did reconnect")
-        
+
         if hasListeners {
             sendEvent(withName: "CallReconnected", body: ["callSid": call.sid])
         }
     }
-    
+
     func callDidDisconnect(call: Call, error: Error?) {
         if let error = error {
             NSLog("[TwilioPhone] Call disconnected with error: \(error.localizedDescription)")
-            
+
             if hasListeners {
                 sendEvent(withName: "CallDisconnectedError", body: [
                     "callSid": call.sid,
@@ -333,12 +351,12 @@ extension TwilioPhone: CallDelegate {
             }
         } else {
             NSLog("[TwilioPhone] Call disconnected")
-            
+
             if hasListeners {
                 sendEvent(withName: "CallDisconnected", body: ["callSid": call.sid])
             }
         }
-        
+
         activeCalls.removeValue(forKey: call.sid)
     }
 }
@@ -348,16 +366,16 @@ extension TwilioPhone: CallDelegate {
 extension TwilioPhone: NotificationDelegate {
     func callInviteReceived(callInvite: CallInvite) {
         NSLog("[TwilioPhone] Call invite received")
-        
+
         activeCallInvites[callInvite.callSid] = callInvite
-        
+
         let callerInfo: TVOCallerInfo = callInvite.callerInfo
         if let verified: NSNumber = callerInfo.verified {
             if verified.boolValue {
                 NSLog("[TwilioPhone] Call invite received from verified caller number")
             }
         }
-        
+
         if hasListeners {
             sendEvent(withName: "CallInvite", body: [
                 "callSid": callInvite.callSid,
@@ -365,12 +383,12 @@ extension TwilioPhone: NotificationDelegate {
             ])
         }
     }
-    
+
     func cancelledCallInviteReceived(cancelledCallInvite: CancelledCallInvite, error: Error) {
         NSLog("[TwilioPhone] Cancelled call invite received")
-        
+
         activeCallInvites.removeValue(forKey: cancelledCallInvite.callSid)
-        
+
         if hasListeners {
             sendEvent(withName: "CancelledCallInvite", body: ["callSid": cancelledCallInvite.callSid])
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ type TwilioPhoneType = {
   endCall(callSid: string): void;
   toggleMuteCall(callSid: string, mute: boolean): void;
   toggleHoldCall(callSid: string, hold: boolean): void;
+  toggleSpeaker(speakerOn: boolean): void;
   sendDigits(callSid: string, digits: string): void;
   startCall(accessToken: string, params: ConnectParams): void;
   unregister(accessToken: string, deviceToken: string): void;


### PR DESCRIPTION
Adds support for toggling the speaker on/off during a call (Android and iOS). In my tests on both platforms the system resets the speaker state when a call is started, so it is safe to toggle on and then have the call end without toggling back off programmatically.

Usage: `TwilioPhone.toggleSpeaker(true); // or false to go back to handset speaker`

Also it looks like Xcode went and made a bunch of formatting changes to `TwilioPhone.swift`, sorry about that.