### PR TITLE
Allow passing additional params to startCall function

### DIFF
--- a/src/RNTwilioPhone.ts
+++ b/src/RNTwilioPhone.ts
@@ -113,7 +113,12 @@ class RNTwilioPhone {
     });
   }
 
-  static async startCall(to: string, calleeName?: string, from?: string) {
+  static async startCall(
+    to: string,
+    calleeName?: string,
+    from?: string,
+    additionalParams: ConnectParams = {}
+  ) {
     const accessToken = await RNTwilioPhone.fetchAccessToken();
     const params: ConnectParams = { to };
 
@@ -121,7 +126,10 @@ class RNTwilioPhone {
       params.from = from;
     }
 
-    TwilioPhone.startCall(accessToken, params);
+    TwilioPhone.startCall(accessToken, {
+      ...params,
+      ...additionalParams,
+    });
 
     const uuid = ramdomUuid().toLowerCase();
     RNTwilioPhone.activeCall = { uuid: null, sid: null };


### PR DESCRIPTION
The Twilio function can receive an "any" object as params. So I would like to enhance this method to fit with it, instead of only support 2 keys "from", "to" as current.
