### PR TITLE
Add payload to calls

### DIFF
--- a/src/RNTwilioPhone.ts
+++ b/src/RNTwilioPhone.ts
@@ -17,6 +17,7 @@ export type RNTwilioPhoneOptions = {
 type Call = {
   uuid: string | null;
   sid: string | null;
+  payload: object | null;
 };
 
 const defaultOptions: RNTwilioPhoneOptions = {
@@ -132,7 +133,7 @@ class RNTwilioPhone {
     });
 
     const uuid = ramdomUuid().toLowerCase();
-    RNTwilioPhone.activeCall = { uuid: null, sid: null };
+    RNTwilioPhone.activeCall = { uuid: null, sid: null, payload: null };
 
     RNCallKeep.startCall(uuid, to, calleeName, 'generic');
   }
@@ -209,7 +210,7 @@ class RNTwilioPhone {
           // Incoming call is already reported to CallKit on iOS
           if (Platform.OS === 'android') {
             const uuid = ramdomUuid().toLowerCase();
-            RNTwilioPhone.addCall({ uuid, sid: callSid });
+            RNTwilioPhone.addCall({ uuid, sid: callSid, payload: null });
 
             RNCallKeep.displayIncomingCall(uuid, from);
           }
@@ -291,7 +292,8 @@ class RNTwilioPhone {
       RNCallKeep.addEventListener(
         'didDisplayIncomingCall',
         ({ callUUID, payload }) => {
-          RNTwilioPhone.addCall({ uuid: callUUID, sid: payload.twi_call_sid });
+          const { aps, ...sanitizedPayload } = payload;
+          RNTwilioPhone.addCall({ uuid: callUUID, sid: sanitizedPayload.twi_call_sid, payload: sanitizedPayload });
         }
       );
 


### PR DESCRIPTION
Hi!

Thank you for making this library! We are planning on using it in production for an app in relation with healthcare and so far this is the best option we've found to integrate Twilio Voice into a React Native app.

The goal of this PR is to update the `didDisplayIncomingCall` event listener that the library adds to `RNCallKeep`, so that the payload (sanitized so it doesn't contain the `aps` property) is also passed to the call we add via `RNTwilioPhone`. This permits to pass custom parameters to the calls via the instruction TwiML. I saw someone created an issue in order to discuss doing just that: https://github.com/MrHertal/react-native-twilio-phone/issues/56

Since this is using the payload we pass via CallKeep, this solution only concerns iOS. Our app does not support Android yet, but we plan on doing so in the future. When the time comes, I'll investigate on a potential solution for Android too (via Firebase I imagine, but I haven't looked into it at all).

I hope this helps!