### PR TITLE
TwilioPhone: Add method to retrieve current call stats.

### DIFF
--- a/ios/TwilioPhone.m
+++ b/ios/TwilioPhone.m
@@ -15,6 +15,8 @@ RCT_EXTERN_METHOD(disconnectCall:(NSString *)callSid)
 
 RCT_EXTERN_METHOD(endCall:(NSString *)callSid)
 
+RCT_EXTERN_METHOD(getCallStats:(NSString *)callSid resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(toggleMuteCall:(NSString *)callSid withMute:(BOOL *)mute)
 
 RCT_EXTERN_METHOD(toggleHoldCall:(NSString *)callSid withHold:(BOOL *)hold)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,18 @@ export enum PermissionStatus {
 export type MessagePayload = Record<string, any>;
 export type ConnectParams = Record<string, string>;
 export type Permissions = Record<PermissionName, PermissionStatus>;
+export type CallStats = {
+  localAudioTrackStats: Array<{
+    audioLevel: number,
+    jitter: number,
+    roundTripTime: number,
+  }>,
+  remoteAudioTrackStats: Array<{
+    audioLevel: number,
+    jitter: number,
+    mos: number
+  }>
+}
 
 type TwilioPhoneType = {
   register(accessToken: string, deviceToken: string): void;
@@ -25,6 +37,7 @@ type TwilioPhoneType = {
   rejectCallInvite(callSid: string): void;
   disconnectCall(callSid: string): void;
   endCall(callSid: string): void;
+  getCallStats(callSid: string): Promise<CallStats>;
   toggleMuteCall(callSid: string, mute: boolean): void;
   toggleHoldCall(callSid: string, hold: boolean): void;
   toggleSpeaker(speakerOn: boolean): void;


### PR DESCRIPTION
As suggested in #38, I added a new method that returns a Promise with the primary audio quality and audio level statistics reported by Twilio.