### PR TITLE
avoid firebase messaging import on ios

### DIFF
--- a/src/RNTwilioPhone.ts
+++ b/src/RNTwilioPhone.ts
@@ -9,7 +9,18 @@ import {
 import VoipPushNotification from 'react-native-voip-push-notification';
 import ramdomUuid from 'uuid-random';
 
-let messaging
+type callback = (param: any) => any;
+
+interface FirebaseMessagingModule {
+  (): FirebaseMessagingModule;
+  setBackgroundMessageHandler: (handler: callback) => any;
+  getToken: () => Promise<any>;
+  onTokenRefresh: (handler: callback) => any;
+  onMessage: (handler: callback) => any;
+};
+
+let messaging: FirebaseMessagingModule;
+
 if (Platform.OS === 'android') {
   messaging = require('@react-native-firebase/messaging')
 }

--- a/src/RNTwilioPhone.ts
+++ b/src/RNTwilioPhone.ts
@@ -1,4 +1,3 @@
-import messaging from '@react-native-firebase/messaging';
 import { Platform } from 'react-native';
 import RNCallKeep, { IOptions } from 'react-native-callkeep';
 import {
@@ -9,6 +8,11 @@ import {
 } from 'react-native-twilio-phone';
 import VoipPushNotification from 'react-native-voip-push-notification';
 import ramdomUuid from 'uuid-random';
+
+let messaging
+if (Platform.OS === 'android') {
+  messaging = require('@react-native-firebase/messaging')
+}
 
 export type RNTwilioPhoneOptions = {
   requestPermissionsOnInit: boolean; // Default: true


### PR DESCRIPTION
ios project does not need firebase since that is only used for android. attempting to import firebase messaging in ios project breaks. [issue](https://github.com/MrHertal/react-native-twilio-phone/issues/95). maybe this works if you actually install the pods and so on but there's a ton of subdependencies with special build configurations etc that I don't really want to deal with especially since that code will never even be called in an ios app.

this changes import of firebase messaging to conditional import since it is only conditionally used on android.

